### PR TITLE
modify iptables interaction

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,29 @@
   - iptables
   - ip6tables
 
+- name: blacklist iptables kernel modules
+  kernel_blacklist:
+    name: "{{ item }}"
+  become: yes
+  loop:
+  - ip_tables
+  - ip6_tables
+  - arp_tables
+  - eb_tables
+  - x_tables
+
+- name: remove iptables kernel modules
+  modprobe:
+    name: "{{ item }}"
+    state: absent
+  become: yes
+  loop:
+  - ip_tables
+  - ip6_tables
+  - arp_tables
+  - eb_tables
+  - x_tables
+
 - name: ensure /etc/nftables.d/ exists
   file:
     state: directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,11 +3,16 @@
     name: nftables
   become: yes
 
-- name: ensure iptables is not installed
-  package:
-    name: iptables
-    state: absent
+- name: ensure iptables service is stopped & disabled
+  service:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+  failed_when: no
   become: yes
+  loop:
+  - iptables
+  - ip6tables
 
 - name: ensure /etc/nftables.d/ exists
   file:


### PR DESCRIPTION
This disables and stops the iptables services, instead of uninstalling the whole package,
and tries to remove and blacklist the corresponding iptables kernel modules.