### PR TITLE
Refactor rules

### DIFF
--- a/templates/30-global.nft
+++ b/templates/30-global.nft
@@ -47,6 +47,9 @@ table inet filter {
 
     # SSH is open by default but we can enforce a strict policy earlier
     tcp dport ssh accept;
+
+    # Reject some politely before using drop policy
+    limit rate 60/minute reject;
   }
 }
 

--- a/templates/30-global.nft
+++ b/templates/30-global.nft
@@ -2,6 +2,11 @@
 
 
 table inet filter {
+
+  map iif_verdict {
+    type iface_index : verdict;
+    elements = { lo : accept };
+  }
   map udp_dport_verdict {
     type inet_service : verdict;
   }
@@ -33,6 +38,9 @@ table inet filter {
 
   chain input {
     type filter hook input priority 0; policy drop;
+
+    # Allow interface-based verdicts
+    iif vmap @iif_verdict;
 
     # Do the basic filtering
     jump base;

--- a/templates/30-global.nft
+++ b/templates/30-global.nft
@@ -12,6 +12,7 @@ table inet filter {
   }
   map tcp_dport_verdict {
     type inet_service : verdict;
+    elements = { ssh : accept };
   }
 
   chain basic_filter {
@@ -33,6 +34,12 @@ table inet filter {
     ip protocol icmp   drop;
   }
 
+  chain port_filter {
+    # Allow port-based verdicts
+    udp dport vmap @udp_dport_verdict;
+    tcp dport vmap @tcp_dport_verdict;
+  }
+
   chain input {
     type filter hook input priority 0; policy drop;
 
@@ -40,13 +47,7 @@ table inet filter {
     iif vmap @iif_verdict;
 
     jump basic_filter;
-
-    # Jump to the appropriate chain
-    udp dport vmap @udp_dport_verdict;
-    tcp dport vmap @tcp_dport_verdict;
-
-    # SSH is open by default but we can enforce a strict policy earlier
-    tcp dport ssh accept;
+    jump port_filter;
 
     # Reject some politely before using drop policy
     limit rate 60/minute reject;

--- a/templates/30-global.nft
+++ b/templates/30-global.nft
@@ -1,15 +1,16 @@
 {{ ansible_managed|comment }}
 
-
 table inet filter {
 
   map iif_verdict {
     type iface_index : verdict;
     elements = { lo : accept };
   }
+
   map udp_dport_verdict {
     type inet_service : verdict;
   }
+
   map tcp_dport_verdict {
     type inet_service : verdict;
     elements = { ssh : accept };
@@ -53,7 +54,3 @@ table inet filter {
     limit rate 60/minute reject;
   }
 }
-
-# Do this in the future when it is finally supported
-# flush map udp_dport_verdict;
-# flush map tcp_dport_verdict;

--- a/templates/30-global.nft
+++ b/templates/30-global.nft
@@ -14,7 +14,12 @@ table inet filter {
     type inet_service : verdict;
   }
 
-  chain base {
+  chain basic_filter {
+
+    # Fast path for established connections
+    ct state established,related accept;
+    ct state invalid drop;
+
     # Limit pingv6 requests to 10 per second
     ip6 nexthdr icmpv6 icmpv6 type echo-request limit rate 10/second accept;
     ip6 nexthdr icmpv6 icmpv6 type echo-request drop;
@@ -30,10 +35,6 @@ table inet filter {
     # Limit other icmp packets to 10 per minute
     ip protocol icmp limit rate 10/minute accept;
     ip protocol icmp drop;
-
-    # Utilize connection tracking
-    ct state established,related accept;
-    ct state invalid drop;
   }
 
   chain input {
@@ -42,8 +43,7 @@ table inet filter {
     # Allow interface-based verdicts
     iif vmap @iif_verdict;
 
-    # Do the basic filtering
-    jump base;
+    jump basic_filter;
 
     # Jump to the appropriate chain
     udp dport vmap @udp_dport_verdict;

--- a/templates/30-global.nft
+++ b/templates/30-global.nft
@@ -20,21 +20,17 @@ table inet filter {
     ct state established,related accept;
     ct state invalid drop;
 
-    # Limit pingv6 requests to 10 per second
+    # Limit icmp ping requests to 10 per second
     ip6 nexthdr icmpv6 icmpv6 type echo-request limit rate 10/second accept;
     ip6 nexthdr icmpv6 icmpv6 type echo-request drop;
+    ip protocol icmp   icmp   type echo-request limit rate 10/second accept;
+    ip protocol icmp   icmp   type echo-request drop;
 
-    # Limit other icmpv6 packets to 10 per minute
+    # Limit non-ping icmp packets to 10 per minute
     ip6 nexthdr icmpv6 limit rate 10/minute accept;
     ip6 nexthdr icmpv6 drop;
-
-    # Limit ping requests to 10 per second
-    ip protocol icmp icmp type echo-request limit rate 10/second accept;
-    ip protocol icmp icmp type echo-request drop;
-
-    # Limit other icmp packets to 10 per minute
-    ip protocol icmp limit rate 10/minute accept;
-    ip protocol icmp drop;
+    ip protocol icmp   limit rate 10/minute accept;
+    ip protocol icmp   drop;
   }
 
   chain input {


### PR DESCRIPTION
These commits contain the changes we previously discussed.
The focus is placed primarily on extensibility.

Noteable functional changes are
  - interface-based verdicts
  - allowing loopback traffic by default
  - extracting port filtering to a reusable chain
  - doing a limited reject before dropping

Please let me know if you'd like to see anything changed.